### PR TITLE
fix: Add create proposals. #8

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -40,7 +40,9 @@ func CreateRootCommand() *cobra.Command {
 
 	delegateCmd := CreateDelegateCmd()
 
-	rootCmd.AddCommand(completionCmd, versionCmd, singletonCmd, singletonL2Cmd, proxyCmd, factoryCmd, delegateCmd)
+	proposalCmd := CreateSafeProposalCmd()
+
+	rootCmd.AddCommand(completionCmd, versionCmd, singletonCmd, singletonL2Cmd, proxyCmd, factoryCmd, delegateCmd, proposalCmd)
 
 	// By default, cobra Command objects write to stderr. We have to forcibly set them to output to
 	// stdout.

--- a/proposal.go
+++ b/proposal.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+
+	"github.com/G7DAO/safes/bindings/Safe"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/spf13/cobra"
+)
+
+func CreateSafeProposalCmd() *cobra.Command {
+	proposalCmd := &cobra.Command{
+		Use:   "proposal",
+		Short: "Manage proposals for a Safe",
+		Long:  `Manage Safe proposals — create new ones, list existing ones, approve pending ones, and execute approved proposals.`,
+	}
+
+	proposalCmd.AddCommand(createSafeProposalCmd())
+	proposalCmd.SetOut(os.Stdout)
+
+	return proposalCmd
+}
+
+func createSafeProposalCmd() *cobra.Command {
+	var (
+		calldata          string
+		safe              string
+		safeOperationType uint8
+		to                string
+		value             string
+		keyfile           string
+		password          string
+	)
+
+	createProposalCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new proposal for a Safe",
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if safe == "" {
+				return fmt.Errorf("--safe not specified")
+			} else if !common.IsHexAddress(safe) {
+				return fmt.Errorf("invalid safe address: %s", safe)
+			}
+			if to == "" {
+				return fmt.Errorf("--to not specified")
+			} else if !common.IsHexAddress(to) {
+				return fmt.Errorf("invalid to address: %s", to)
+			}
+			if calldata != "" {
+				if !strings.HasPrefix(calldata, "0x") {
+					calldata = "0x" + calldata
+				}
+				if _, err := hex.DecodeString(strings.TrimPrefix(calldata, "0x")); err != nil {
+					return fmt.Errorf("invalid calldata hex: %v", err)
+				}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			toAddr := common.HexToAddress(to).Hex()
+			safeAddr := common.HexToAddress(safe).Hex()
+
+			key, keyErr := KeyFromFile(keyfile, password)
+			if keyErr != nil {
+				return keyErr
+			}
+
+			client, err := ethclient.Dial(rpcURL)
+			if err != nil {
+				return fmt.Errorf("failed to connect to the Ethereum client: %v", err)
+			}
+
+			chainID, err := client.ChainID(context.Background())
+			if err != nil {
+				return fmt.Errorf("failed to get chain ID: %v", err)
+			}
+
+			parsedValue := new(big.Int)
+			if _, ok := parsedValue.SetString(value, 10); !ok {
+				return fmt.Errorf("invalid value: %s", value)
+			}
+
+			if safeAPIURL == "" {
+				safeAPIURL = fmt.Sprintf("https://safe-client.safe.global/v1/chains/%s/transactions/%s/propose", chainID.String(), safeAddr)
+				fmt.Println("safe-api is not set, using default: ", safeAPIURL)
+			} else {
+				fmt.Println("Using custom safe-api URL: ", safeAPIURL)
+			}
+
+			err = CreateSafeProposal(common.HexToAddress(safeAddr), toAddr, parsedValue.String(), calldata, Safe.SafeOperationType(safeOperationType), chainID, key, client, safeAPIURL)
+			if err != nil {
+				cmd.Printf("Error creating proposal: %v\n", err)
+				return fmt.Errorf("error creating proposal: %v", err)
+			}
+
+			fmt.Println("Proposal submitted to:", safeAPIURL)
+			return nil
+		},
+	}
+
+	createProposalCmd.Flags().StringVar(&safe, "safe", "", "Safe address")
+	createProposalCmd.Flags().StringVar(&to, "to", "", "Recipient address")
+	createProposalCmd.Flags().StringVarP(&keyfile, "keyfile", "k", "", "Path to the keystore file")
+	createProposalCmd.Flags().StringVarP(&password, "password", "p", "", "Password for the keystore file")
+	createProposalCmd.Flags().StringVar(&rpcURL, "rpc", "", "RPC URL to retrieve chain ID")
+	createProposalCmd.Flags().StringVar(&safeAPIURL, "safe-api", "", "Override default Safe API URL")
+	createProposalCmd.Flags().StringVar(&value, "value", "", "Value to send with the transaction")
+	createProposalCmd.Flags().StringVar(&calldata, "calldata", "", "Hex-encoded ABI calldata to be sent with the transaction (e.g., function selector and arguments).")
+	createProposalCmd.Flags().Uint8Var(&safeOperationType, "safe-operation", 0, "Safe operation type: 0 (Call) or 1 (DelegateCall)")
+	createProposalCmd.MarkFlagRequired("keyfile")
+	createProposalCmd.MarkFlagRequired("safe")
+
+	return createProposalCmd
+}

--- a/proposalOperations.go
+++ b/proposalOperations.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strings"
+
+	"github.com/G7DAO/safes/bindings/Safe"
+	"github.com/G7DAO/seer/bindings/GnosisSafe"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+func CreateSafeProposal(safeAddress common.Address, to string, value string, calldata string, safeOperationType Safe.SafeOperationType, chainID *big.Int, key *keystore.Key, client *ethclient.Client, safeApi string) error {
+	safeInstance, err := GnosisSafe.NewGnosisSafe(safeAddress, client)
+	if err != nil {
+		return fmt.Errorf("failed to create GnosisSafe instance: %w", err)
+	}
+
+	nonce, err := safeInstance.Nonce(&bind.CallOpts{})
+	if err != nil {
+		return fmt.Errorf("failed to fetch nonce: %w", err)
+	}
+
+	txData := Safe.SafeTransactionData{
+		To:             to,
+		Value:          value,
+		Data:           calldata,
+		Operation:      safeOperationType,
+		SafeTxGas:      0,
+		BaseGas:        0,
+		GasPrice:       "0",
+		GasToken:       Safe.NativeTokenAddress,
+		RefundReceiver: Safe.NativeTokenAddress,
+		Nonce:          nonce,
+	}
+
+	// Compute the hash of the transaction for signing
+	safeTxHash, err := Safe.CalculateSafeTxHash(safeAddress, txData, chainID)
+	if err != nil {
+		return fmt.Errorf("failed to calculate SafeTxHash: %w", err)
+	}
+
+	// Sign the hash with the user's private key
+	signature, err := crypto.Sign(safeTxHash.Bytes(), key.PrivateKey)
+	if err != nil {
+		return fmt.Errorf("failed to sign SafeTxHash: %w", err)
+	}
+
+	// Adjust the V value for Ethereum signature replay protection
+	signature[64] += 27
+	senderSignature := "0x" + common.Bytes2Hex(signature)
+
+	requestBody := map[string]interface{}{
+		"to":             txData.To,
+		"value":          txData.Value,
+		"data":           "0x" + txData.Data,
+		"operation":      int(txData.Operation),
+		"safeTxGas":      fmt.Sprintf("%d", txData.SafeTxGas),
+		"baseGas":        fmt.Sprintf("%d", txData.BaseGas),
+		"gasPrice":       txData.GasPrice,
+		"gasToken":       txData.GasToken,
+		"refundReceiver": txData.RefundReceiver,
+		"nonce":          fmt.Sprintf("%d", txData.Nonce),
+		"safeTxHash":     safeTxHash.Hex(),
+		"sender":         key.Address.Hex(),
+		"signature":      senderSignature,
+		"origin":         fmt.Sprintf("{\"url\":\"%s\",\"name\":\"SafeProposal Creation\"}", safeApi),
+	}
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", safeApi, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		var jsonErr interface{}
+		if err := json.Unmarshal(body, &jsonErr); err != nil {
+			return fmt.Errorf("HTTP %d, failed to parse error body: %s", resp.StatusCode, string(body))
+		}
+		formatted, _ := json.MarshalIndent(jsonErr, "", "  ")
+		return fmt.Errorf("HTTP %d, error response:\n%s", resp.StatusCode, formatted)
+	}
+
+	fmt.Println("Safe proposal created successfully")
+	return nil
+}
+
+func IsValidHex(s string) bool {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		s = s[2:]
+	}
+
+	if len(s) == 0 {
+		return false
+	}
+
+	if len(s)%2 != 0 {
+		return false
+	}
+
+	_, err := hex.DecodeString(s)
+	return err == nil
+}


### PR DESCRIPTION
@karacurt @zomglings This PR introduces functionality for managing safe proposals in the proposal.go and proposalOperations.go files. Key highlights include:

**Command Structure**: Implements the CreateSafeProposalCmd command for creating new proposals.

**Input Validation**: Validates required flags --safe (safe address) and --to (recipient address) to ensure they are valid hex addresses.

**Off-Chain Proposal Creation**: Supports off-chain creation of safe proposals by utilizing the --to and --calldata flags for specifying the recipient and transaction data.

**Transaction Preparation**: Constructs the necessary transaction data and handles signature generation for proposals.

This enhancement streamlines the proposal creation process, ensuring accurate and efficient interactions with the Safe Transaction Service.

fixes#8.

